### PR TITLE
websocket return HTTP 400 when proxy pass 

### DIFF
--- a/AdminHelp.md
+++ b/AdminHelp.md
@@ -1,6 +1,7 @@
 Script Example
                 
-    show()//show chatbox
+    //show chatbox
+    show()
     //hide chatbox
     hide()
     //change page background color

--- a/AdminHelp.md
+++ b/AdminHelp.md
@@ -1,23 +1,24 @@
 Script Example
                 
-    show()
-    //show chatbox
-    hide()
+    show()//show chatbox
     //hide chatbox
-    color('black')
+    hide()
     //change page background color
-    say('I admire you!')
+    color('black')
     //make user say 'I admire you' publicly<br/>
-    type('I love you')
+    say('I admire you!')
     //make user type 'I love you' in his input bar(won't send)<br/>
-    send()
+    type('I love you')
     //make user send whatever is in his input bar publicly<br/>
-    beep()
+    send()
     //play user join sound<br/>
-    newMsgBeep()
+    beep()
     //play new message sound<br/>
-    window.location = "http://www.example.com"
+    newMsgBeep()
+    //change the visitor name
+    changeName("old name","new name")
     //Redirect user to "www.example.com"
+    window.location = "http://www.example.com"
 
     $.getScript("https://cdn.jsdelivr.net/jquery.jrumble/1.3/jquery.jrumble.min.js", function(data, textStatus, jqxhr) {
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ If you want hide the port like `localhost` (Not `localhost:4321`) in front page,
 
 Quick way to change the port(e.g., change to 2231):
 ```
-sed -i 's/var port =.*/var port = 2231;/g' ./public/client.js
-sed -i 's/var port =.*/var port = 2231;/g' ./index.js
+$ sed -i 's/var port =.*/var port = 2231;/g' ./public/client.js
+$ sed -i 's/var port =.*/var port = 2231;/g' ./index.js
 ```
 
 Same way to change the token(e.g., change to 54321):
 ```
-sed -i 's/var token =.*/var token = "54321";/g' ./index.js
+$ sed -i 's/var token =.*/var token = "54321";/g' ./index.js
 ```
 
 To embed this chatbox into a web page, just copy paste the content in public/index.html to the page you want to have chatbox, then change all included css file and JavaScript file path correctly. This app works great with light box library, I personally recommend using fancybox. 
@@ -88,13 +88,13 @@ $ node index.js
 
 通过Shell快速修改端口（比如改成2231）：
 ```
-sed -i 's/var port =.*/var port = 2231;/g' ./public/client.js
-sed -i 's/var port =.*/var port = 2231;/g' ./index.js
+$ sed -i 's/var port =.*/var port = 2231;/g' ./public/client.js
+$ sed -i 's/var port =.*/var port = 2231;/g' ./index.js
 ```
 
 同理，可以快速修改密码（比如改成54321）：
 ```
-sed -i 's/var token =.*/var token = "54321";/g' ./index.js
+$ sed -i 's/var token =.*/var token = "54321";/g' ./index.js
 ```
 
 如果想把聊天盒嵌入网站中，只要将`public/index.html`文件的内容复制粘贴到想要显示聊天盒的网页里，同时`public/index.html`中所有引入css和JavaScript文件地址需要修改正确。推荐配合fancybox插件使用来放大聊天盒里的图片。

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ failed: Error during WebSocket handshake: Unexpected response code: 400
 ```
 This is almost certainly due to not using https (SSL). Websocket over plain http is vulnerable to proxies in the middle (often transparent) operating at the http layer breaking the connection.The only way to avoid this is to use SSL all the time - this gives websocket the best chance of working.
 
+For ways on how this could happen, see [subsection 4.2.1 of the WebSockets RFC 6455](http://tools.ietf.org/html/rfc6455#section-4.2.1).
+
 ##### Future plan
 
 * Improve chat history feature, currently only storing latest 20 messages
@@ -103,7 +105,9 @@ $ sed -i 's/var token =.*/var token = "54321";/g' ./index.js
 ```
 failed: Error during WebSocket handshake: Unexpected response code: 400
 ```
-比较大的可能是在前端隐藏了端口并使用了http，Websocket通信在使用80端口转发时，80端口只负责连接，握手及通信需直接与后端端口通讯。使用https可以避免这个问题，握手通讯皆用443端口。如果你不想使用https，那么建议你通过使用`http://localhost:4321`的方式来使用，而不隐藏端口；抑或是直接使nodejs监听80端口，而不要通过反代。
+比较大的可能是在前端隐藏了端口并使用了http，具体可以看上面英文解释。简单来说Websocket通信在使用80端口转发时，80端口只负责连接，握手及通信在反代转发到后端端口通讯时可能会出错（在HTTP层被断开）。使用https可以避免这个问题，握手通讯皆用443端口。如果你不想使用https，那么建议你通过使用`http://localhost:4321`的方式来使用，而不隐藏端口；抑或是直接使nodejs监听80端口，而不要通过反代。
+
+更多资料可以参照WebSockets RFC 6455协议中的4.2.1章，[传送门](http://tools.ietf.org/html/rfc6455#section-4.2.1)。
 
 
 ##### 下一步

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ sed -i 's/var token =.*/var token = "54321";/g' ./index.js
 
 To embed this chatbox into a web page, just copy paste the content in public/index.html to the page you want to have chatbox, then change all included css file and JavaScript file path correctly. This app works great with light box library, I personally recommend using fancybox. 
 
+If you get error in front page:
+```
+failed: Error during WebSocket handshake: Unexpected response code: 400
+```
+This is almost certainly due to not using https (SSL). Websocket over plain http is vulnerable to proxies in the middle (often transparent) operating at the http layer breaking the connection.The only way to avoid this is to use SSL all the time - this gives websocket the best chance of working.
+
 ##### Future plan
 
 * Improve chat history feature, currently only storing latest 20 messages
@@ -92,6 +98,12 @@ sed -i 's/var token =.*/var token = "54321";/g' ./index.js
 ```
 
 如果想把聊天盒嵌入网站中，只要将`public/index.html`文件的内容复制粘贴到想要显示聊天盒的网页里，同时`public/index.html`中所有引入css和JavaScript文件地址需要修改正确。推荐配合fancybox插件使用来放大聊天盒里的图片。
+
+如果你在调试时出现：
+```
+failed: Error during WebSocket handshake: Unexpected response code: 400
+```
+比较大的可能是在前端隐藏了端口并使用了http，Websocket通信在使用80端口转发时，80端口只负责连接，握手及通信需直接与后端端口通讯。使用https可以避免这个问题，握手通讯皆用443端口。如果你不想使用https，那么建议你通过使用`http://localhost:4321`的方式来使用，而不隐藏端口；抑或是直接使nodejs监听80端口，而不要通过反代。
 
 
 ##### 下一步

--- a/conf/chatbox.conf
+++ b/conf/chatbox.conf
@@ -1,0 +1,21 @@
+server {
+  listen 443 ssl http2;
+  server_name chatbox.kn007.net;
+  include kn007_net_security.conf;
+  location ~ ^/admin\.html {
+    proxy_pass http://127.0.0.1:2231;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+	auth_basic "kn007's Auth System";
+	auth_basic_user_file /usr/local/nginx/passwd_chatbox.db;
+  }
+  location / {
+    proxy_pass http://127.0.0.1:2231;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+  }
+}


### PR DESCRIPTION
	websocket return HTTP 400 when proxy pass 
	Add dollar sign
	add more information for Websocket RFC

failed: Error during WebSocket handshake: Unexpected response code: 400

sometimes see the error (not always).